### PR TITLE
Fix python 3 map error in multilang

### DIFF
--- a/storm-multilang/python/src/main/resources/resources/storm.py
+++ b/storm-multilang/python/src/main/resources/resources/storm.py
@@ -109,7 +109,7 @@ def emitBolt(tup, stream=None, anchors = [], directTask=None):
     m = {"command": "emit"}
     if stream is not None:
         m["stream"] = stream
-    m["anchors"] = map(lambda a: a.id, anchors)
+    m["anchors"] = [ a.id for a in anchors ]
     if directTask is not None:
         m["task"] = directTask
     m["tuple"] = tup


### PR DESCRIPTION
In Python 3, map returns an iterable object which is not serializable. This breaks when we try to encode it on line 78:

TypeError: <map object at 0x7fb659dfef98> is not JSON serializable
